### PR TITLE
:sparkles:Feat: 메인페이지, 물품 상세페이지(구매자,판매자), 관심상품 등록/해제 구현완료

### DIFF
--- a/src/Apis/productApi.js
+++ b/src/Apis/productApi.js
@@ -15,9 +15,19 @@ const ProductApi = {
 		});
 	},
 
+	mainList() {
+		return Axios.get(PATH);
+	},
+
 	detail(id) {
 		return Axios.get(PATH + '/detail', {
 			params: { prod_idx: id },
+		});
+	},
+
+	likedBtn(prod_idx) {
+		return Axios.post(PATH + '/like', {
+			prod_idx,
 		});
 	},
 };

--- a/src/Components/Buttons/HeartBtn/HeartBtn.js
+++ b/src/Components/Buttons/HeartBtn/HeartBtn.js
@@ -1,14 +1,28 @@
+import ProductApi from 'Apis/productApi';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const HeartBtn = () => {
-	const [active, setActive] = useState(false);
+const HeartBtn = ({ like, idx }) => {
+	const [liked, setLiked] = useState(like);
 
-	const handleClick = () => {
-		setActive(!active);
+	const toggleLiked = async index => {
+		try {
+			const response = await ProductApi.likedBtn(index);
+			if (response.status === 200) {
+				setLiked(prev => !prev);
+				console.log('관심상품등록됨', liked);
+			}
+		} catch (error) {
+			console.log('에러', error);
+		}
 	};
 
-	return <S.Button className={active ? 'active' : ''} onClick={handleClick} />;
+	return (
+		<S.Button
+			className={liked ? 'active' : ''}
+			onClick={() => toggleLiked(idx)}
+		/>
+	);
 };
 
 export default HeartBtn;

--- a/src/Components/Card/Desktop/Card.js
+++ b/src/Components/Card/Desktop/Card.js
@@ -1,25 +1,39 @@
 import HeartBtn from 'Components/Buttons/HeartBtn/HeartBtn';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-const ItemCard = () => {
-	// const navigate = useNavigate();
+const ItemCard = ({ index, products }) => {
+	const navigate = useNavigate();
+
+	const onClickCard = async () => {
+		navigate(`/item_detail/${index}`);
+	};
 
 	return (
-		<S.Wrapper>
-			{/*onClick={() => navigate(`/detail/${item.id}`)} */}
-			<S.Container>
-				<S.Heart>
-					<HeartBtn />
-				</S.Heart>
-				<S.ItemImg src="Assets/Images/bicycle.jpg" />
-				<S.ItemInfo>
-					<S.ItemTitle>[제목] 제목이 들어갑니다.</S.ItemTitle>
-					<S.ItemPrice>130,000 원</S.ItemPrice>
-					<S.ItemTag>#태그 #태그2 #태그3</S.ItemTag>
-				</S.ItemInfo>
-			</S.Container>
-		</S.Wrapper>
+		products && (
+			<S.Wrapper>
+				<S.Container>
+					<S.Heart>
+						<HeartBtn like={products.liked} idx={products.idx} />
+					</S.Heart>
+					<div onClick={onClickCard}>
+						<S.ItemImg src={products.img_url} />
+						<S.ItemInfo>
+							<S.ItemTitle>{products.title}</S.ItemTitle>
+							<S.ItemPrice>
+								{products.price.toLocaleString('ko-KR')}원
+							</S.ItemPrice>
+							{products.ProductsTags.map(tagObj => (
+								<S.ItemTag key={tagObj.idx}>
+									<a className="tag-link">#{tagObj.Tag.tag}</a>
+								</S.ItemTag>
+							))}
+						</S.ItemInfo>
+					</div>
+				</S.Container>
+			</S.Wrapper>
+		)
 	);
 };
 
@@ -36,7 +50,9 @@ const Container = styled.div`
 	margin-right: 10px;
 	margin-top: 10px;
 	margin-bottom: 10px;
+	border: 1px solid lightgray;
 `;
+
 const Heart = styled.div`
 	position: absolute;
 	width: 25px;
@@ -48,36 +64,46 @@ const Heart = styled.div`
 
 const ItemImg = styled.img`
 	position: relative;
+	max-width: 200px;
 	width: 100%;
-	padding: 15px;
-	max-height: 250px;
+	height: 250px;
 	object-fit: cover;
-	margin: auto;
+	padding: 10px;
 `;
 
 const ItemInfo = styled.div`
 	padding-top: 15px;
 	max-height: 150px;
 	display: flex;
-	flex-direction: column;
-	padding: 0 15px;
+	flex-wrap: wrap;
+\	padding: 0 15px;
 `;
 
 const ItemTitle = styled.div`
+	width: 100%;
 	font-size: ${({ theme }) => theme.fontSize.sm};
 	margin-bottom: 10px;
 `;
 
 const ItemPrice = styled.span`
+	width: 100%;
 	font-size: ${({ theme }) => theme.fontSize.sm};
 	font-weight: ${({ theme }) => theme.fontWeight.bold};
 	margin-bottom: 15px;
 `;
 
 const ItemTag = styled.span`
+	display: inline-block;
 	font-size: ${({ theme }) => theme.fontSize.xs};
-	overflow: hidden;
+	margin-right: 5px;
 	margin-bottom: 10px;
+
+	a {
+		display: inline-block;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 `;
 
 const S = {

--- a/src/Components/Icon/Icon.js
+++ b/src/Components/Icon/Icon.js
@@ -8,13 +8,13 @@ import { flexAllCenter } from 'Styles/common';
 import { useState } from 'react';
 import styled from 'styled-components';
 
-const MannerMeter = () => {
-	const score = (Math.random() * 50).toFixed(1);
+const MannerMeter = ({ ondo }) => {
 	const [state, setState] = useState(false);
+
 	return (
 		<S.Wrapper>
-			<div>{score}점</div>
-			{score >= 36.5 && (
+			<div>{ondo}점</div>
+			{ondo >= 36.5 && (
 				<>
 					<FontAwesomeIcon
 						icon={faFaceSmileWink}
@@ -31,7 +31,7 @@ const MannerMeter = () => {
 					)}
 				</>
 			)}
-			{score < 36.5 && score >= 30 && (
+			{ondo < 36.5 && ondo >= 30 && (
 				<>
 					<FontAwesomeIcon
 						icon={faFaceMeh}
@@ -48,7 +48,7 @@ const MannerMeter = () => {
 					)}
 				</>
 			)}
-			{score < 30 && (
+			{ondo < 30 && (
 				<>
 					<FontAwesomeIcon
 						icon={faFaceDizzy}

--- a/src/Components/Layout/Header/Desktop/index.js
+++ b/src/Components/Layout/Header/Desktop/index.js
@@ -6,7 +6,7 @@ const WebHeader = () => {
 	return (
 		<S.Wrapper>
 			<Link to={'/main'}>
-				<S.Logo src="Assets/web_logo.png"></S.Logo>
+				<S.Logo src="/Assets/web_logo.png"></S.Logo>
 			</Link>
 			<MenuBar />
 		</S.Wrapper>
@@ -16,7 +16,7 @@ const WebHeader = () => {
 export default WebHeader;
 
 const Wrapper = styled.div`
-	width: 100%;
+	width: 60%;
 	min-width: 700px;
 	max-width: 1000px;
 	height: 200px;
@@ -31,7 +31,7 @@ const Wrapper = styled.div`
 const Logo = styled.img`
 	padding-top: 50px;
 	margin-bottom: 50px;
-	width: 300px;
+	width: 320px;
 `;
 
 const S = {

--- a/src/Components/MenuBar/MenuBar.js
+++ b/src/Components/MenuBar/MenuBar.js
@@ -21,7 +21,7 @@ const MenuBar = () => {
 					<S.MyChat props={onChat}>MY CHAT</S.MyChat>
 				</S.Menu>
 
-				<S.Menu to="/mypage">MY PAGE</S.Menu>
+				<S.MyPageMenu to="/mypage">MY PAGE</S.MyPageMenu>
 			</S.RightMenu>
 		</S.Bar>
 	);
@@ -30,9 +30,7 @@ const MenuBar = () => {
 export default MenuBar;
 
 const Bar = styled.div`
-	width: 60%;
-	max-width: 1000px;
-	min-width: 700px;
+	width: 100%;
 	margin: 0 auto;
 	display: flex;
 	font-size: ${({ theme }) => theme.fontSize.base};
@@ -43,7 +41,7 @@ const Bar = styled.div`
 const Menu = styled(Link)`
 	color: ${({ theme }) => theme.color.black};
 	text-decoration: none;
-	padding-right: 10px;
+	padding-right: 20px;
 `;
 const LeftMenu = styled.div`
 	width: 100%;
@@ -61,10 +59,17 @@ const MyChat = styled.div`
 			? ({ theme }) => theme.color.primary
 			: ({ theme }) => theme.color.black};
 `;
+
+const MyPageMenu = styled(Link)`
+	color: ${({ theme }) => theme.color.black};
+	text-decoration: none;
+`;
+
 const S = {
 	Bar,
 	Menu,
 	RightMenu,
 	LeftMenu,
 	MyChat,
+	MyPageMenu,
 };

--- a/src/Pages/ItemDetail/BuyerDetail/BuyerDetail.js
+++ b/src/Pages/ItemDetail/BuyerDetail/BuyerDetail.js
@@ -5,11 +5,13 @@ import { flexAllCenter } from 'Styles/common';
 import AnotherProduct from '../Components/AnotherProduct/anotherProduct';
 import KaMap from 'Components/Map/Map';
 
-const BuyerDetailPage = ({ state }) => {
+const BuyerDetailPage = ({ state, product }) => {
+	const item = product && product.data.searchProduct;
+	console.log(item);
 	return (
 		<S.Wrapper>
-			<DetailHead />
-			<DetailContent state={state} />
+			<DetailHead item={item} />
+			<DetailContent state={state} item={item} />
 			<S.MapContent>
 				<div>거래장소</div>
 				<KaMap />

--- a/src/Pages/ItemDetail/Components/DetailContent/detailContent.js
+++ b/src/Pages/ItemDetail/Components/DetailContent/detailContent.js
@@ -1,43 +1,55 @@
 import HeartBtn from 'Components/Buttons/HeartBtn/HeartBtn';
 import { flexAllCenter } from 'Styles/common';
+import dayjs from 'dayjs';
 import { isDesktop } from 'react-device-detect';
 import styled from 'styled-components';
 
-const DetailContent = ({ state }) => {
+const DetailContent = ({ state, item }) => {
+	const created = item && dayjs(item.createdAt).format('YYYY년 MM월 DD일');
+	const diff = dayjs().diff(item && dayjs(item.createdAt), 'day');
+
+	const date = diff === 0 ? '오늘' : diff < 4 ? `${diff}일전` : created;
+
 	return (
 		<>
-			{state ? (
-				<S.BuyerWrapper isDesktop={isDesktop}>
-					<div>#제목 : 브라운 그레이 자켓 팝니다.</div>
-					<div># 카테고리(여성의류) | 2일전</div>
-					<div>120,000 원</div>
-					<div>
-						본문내용 : 택도 제거 안한 새 제품입니다! 직거래와 택배 모두
-						가능합니다.
-					</div>
-					<div>
-						<div>채팅하기</div>
-						<div>
-							<HeartBtn />
-						</div>
-					</div>
-				</S.BuyerWrapper>
-			) : (
-				<S.SellerWrapper isDesktop={isDesktop}>
-					<div>
-						<div>#제목 : 브라운 그레이 자켓 팝니다.</div>
-						<div>
-							<HeartBtn />
-						</div>
-					</div>
-					<div># 카테고리(여성의류) | 2일전</div>
-					<div>120,000 원</div>
-					<div>
-						본문내용 : 택도 제거 안한 새 제품입니다! 직거래와 택배 모두
-						가능합니다.
-					</div>
-				</S.SellerWrapper>
-			)}
+			{!state
+				? item && (
+						<S.BuyerWrapper isDesktop={isDesktop}>
+							<div>{item.title}</div>
+							<div>
+								{item.ProductsTags.map(item => (
+									<span>#{item.Tag.tag}</span>
+								))}
+								| {date}
+							</div>
+							<div>{item.price.toLocaleString('ko-KR')}원</div>
+							<div>{item.description}</div>
+							<div>
+								<div>채팅하기</div>
+								<div>
+									<HeartBtn like={item.liked} idx={item.idx} />
+								</div>
+							</div>
+						</S.BuyerWrapper>
+				  )
+				: item && (
+						<S.SellerWrapper isDesktop={isDesktop}>
+							<div>
+								<div>{item.title}</div>
+								<div>
+									<HeartBtn like={item.liked} idx={item.idx} />
+								</div>
+							</div>
+							<div>
+								{item.ProductsTags.map(item => (
+									<span>#{item.Tag.tag}</span>
+								))}
+								| {date}
+							</div>
+							<div>{item.price.toLocaleString('ko-KR')}원</div>
+							<div>{item.description}</div>
+						</S.SellerWrapper>
+				  )}
 		</>
 	);
 };
@@ -48,18 +60,27 @@ const BuyerWrapper = styled.div`
 	& > div {
 		margin: 20px 0;
 	}
+	//제목
 	& > div:nth-of-type(1) {
 		font-size: ${({ theme }) => theme.fontSize.big};
 		font-weight: ${({ theme }) => theme.fontWeight.regular};
 	}
+	//태그, 날짜
+	& > div:nth-of-type(2) {
+		display: flex;
+		gap: 5px;
+	}
+	//가격
 	& > div:nth-of-type(3) {
 		font-size: ${({ theme }) => theme.fontSize.md};
 		font-weight: ${({ theme }) => theme.fontWeight.bold};
 	}
+	//본문내용
 	& > div:nth-of-type(4) {
 		font-size: ${({ theme }) => theme.fontSize.base};
 		font-weight: ${({ theme }) => theme.fontWeight.regular};
 	}
+	// 카테고리
 	& > div:nth-of-type(5) {
 		${flexAllCenter}
 		justify-content: space-between;
@@ -69,6 +90,7 @@ const BuyerWrapper = styled.div`
 			padding: 15px 30px;
 			border-radius: 10px;
 		}
+		//heart
 		& > div:last-child {
 			width: 40px;
 			height: 40px;

--- a/src/Pages/ItemDetail/Components/DetailHead/ProductImg/productImg.js
+++ b/src/Pages/ItemDetail/Components/DetailHead/ProductImg/productImg.js
@@ -3,18 +3,39 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 
 import { Navigation } from 'swiper';
+import styled from 'styled-components';
 
-const ProductImg = () => {
+const ProductImg = ({ main, sub }) => {
 	return (
-		<>
-			<Swiper navigation={true} modules={[Navigation]} className="mySwiper">
-				<SwiperSlide>Slide 1</SwiperSlide>
-				<SwiperSlide>Slide 2</SwiperSlide>
-				<SwiperSlide>Slide 3</SwiperSlide>
-				<SwiperSlide>Slide 4</SwiperSlide>
-			</Swiper>
-		</>
+		main && (
+			<>
+				<Swiper navigation={true} modules={[Navigation]} className="mySwiper">
+					<SwiperSlide>
+						<ImgSection
+							src={main}
+							onClick={() => window.open(`${main}`, '_blank')}
+						/>
+					</SwiperSlide>
+					{sub.map(img => (
+						<SwiperSlide>
+							<ImgSection
+								src={img.img_url}
+								onClick={() => window.open(`${img.img_url}`, '_blank')}
+							/>
+						</SwiperSlide>
+					))}
+				</Swiper>
+			</>
+		)
 	);
 };
 
 export default ProductImg;
+
+const ImgSection = styled.img`
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	background: black;
+	margin: 0 auto;
+`;

--- a/src/Pages/ItemDetail/Components/DetailHead/detailHead.js
+++ b/src/Pages/ItemDetail/Components/DetailHead/detailHead.js
@@ -5,31 +5,33 @@ import ProductImg from './ProductImg/productImg';
 import Profile from 'Components/Profile/Desktop/profile';
 import { useNavigate } from 'react-router';
 
-const DetailHead = props => {
+const DetailHead = ({ item }) => {
 	const navigate = useNavigate();
-	const { size } = props;
+
+	console.log(item);
+
 	return (
-		<S.Wrapper>
-			<ProductImg />
-			<S.ProductWrapper>
-				<S.UserProfile>
-					<S.ProfileWrapper size={size}>
-						<Profile />
-					</S.ProfileWrapper>
-					<ul>
-						<li>판매자 닉네임</li>
-						<li>위치 (동까지)</li>
-					</ul>
-				</S.UserProfile>
-				<S.UserProfileDetail>
-					<ul>
-						<MannerMeter />
-						<li>매너점수</li>
-						<li>총 거래건수 : OO건</li>
-					</ul>
-				</S.UserProfileDetail>
-			</S.ProductWrapper>
-		</S.Wrapper>
+		item && (
+			<S.Wrapper>
+				<ProductImg main={item.img_url} sub={item.ProductImages} />
+				<S.ProductWrapper>
+					<S.UserProfile>
+						<S.ProfileWrapper>
+							<Profile />
+						</S.ProfileWrapper>
+						<ul>
+							<li>{item.User.nick_name}</li>
+							<li>{item.region}</li>
+						</ul>
+					</S.UserProfile>
+					<S.UserProfileDetail>
+						<ul>
+							<MannerMeter ondo={item.User.Ondo.ondo} />
+						</ul>
+					</S.UserProfileDetail>
+				</S.ProductWrapper>
+			</S.Wrapper>
+		)
 	);
 };
 

--- a/src/Pages/ItemDetail/SellerDetail/SellerDetail.js
+++ b/src/Pages/ItemDetail/SellerDetail/SellerDetail.js
@@ -7,14 +7,14 @@ import ChattingPage from 'Pages/Chat';
 import AnotherProduct from '../Components/AnotherProduct/anotherProduct';
 import { useNavigate } from 'react-router';
 
-const SellerDetailPage = ({ state }) => {
+const SellerDetailPage = ({ state, product }) => {
+	const item = product && product.data.searchProduct;
 	const [detailState, setDetailState] = useState('상세정보');
 	const navigate = useNavigate();
 
 	const onClickDetailAndChatBar = e => {
 		const { innerText } = e.target;
 		setDetailState(innerText);
-		console.log(detailState);
 	};
 	return (
 		<S.Wrapper>
@@ -25,7 +25,7 @@ const SellerDetailPage = ({ state }) => {
 					<li>Delete</li>
 				</ul>
 			</S.EditBar>
-			<DetailHead />
+			<DetailHead item={item} />
 			<S.DetailAndChatBar>
 				<S.Detail active={detailState} onClick={onClickDetailAndChatBar}>
 					상세정보
@@ -35,7 +35,7 @@ const SellerDetailPage = ({ state }) => {
 				</S.Chat>
 			</S.DetailAndChatBar>
 			{detailState === '상세정보' ? (
-				<DetailContent state={state} />
+				<DetailContent state={state} item={item} />
 			) : (
 				<ChattingPage />
 			)}

--- a/src/Pages/ItemDetail/index.js
+++ b/src/Pages/ItemDetail/index.js
@@ -1,21 +1,37 @@
-import { useState } from 'react';
-
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import ProductApi from 'Apis/productApi';
 import SellerDetailPage from './SellerDetail/SellerDetail';
 import BuyerDetailPage from './BuyerDetail/BuyerDetail';
 
 const ItemDetailPage = () => {
-	const [state, setState] = useState(true);
+	const { idx } = useParams();
+	let state = '';
+	const [product, setProduct] = useState('');
 
-	const onChangeState = () => {
-		setState(prev => !prev);
+	const temp = async () => {
+		try {
+			const res = await ProductApi.detail(idx);
+			setProduct(res);
+		} catch (err) {
+			console.log(err);
+		}
 	};
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+		temp();
+	}, []);
+
+	const { isSeller } = product && product.data;
+	state = isSeller;
+
 	return (
 		<>
-			<button onClick={onChangeState}>버튼</button>
-			{state ? (
-				<BuyerDetailPage state={state} />
+			{!isSeller ? (
+				<BuyerDetailPage state={state} product={product} />
 			) : (
-				<SellerDetailPage state={state} />
+				<SellerDetailPage state={state} product={product} />
 			)}
 		</>
 	);

--- a/src/Pages/Main/Desktop/Components/preview.js
+++ b/src/Pages/Main/Desktop/Components/preview.js
@@ -1,17 +1,19 @@
-import { Axios } from 'Apis/@core';
-import ItemCard from 'Components/Card/Desktop/Card';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import ProductApi from 'Apis/productApi';
+import { useEffect } from 'react';
+import ItemCard from 'Components/Card/Desktop/Card';
 
-const Preview = ({ categoryData, userLocation, userName }) => {
-	let category = categoryData === 1 ? '중고 물품' : '무료나눔';
+const Preview = ({ category }) => {
+	const [data, setData] = useState();
+	const products =
+		data && (category === 0 ? data.usedProduct : data.freeProduct);
+	let categoryDeclare = category === 0 ? '중고 물품' : '무료나눔';
 	let categoryText =
-		categoryData === 1
-			? `${userLocation} 인기 줍줍템!`
-			: `${userName}님 주변의 무료나눔 물품들 이에요!`;
-
-	const itemList = [1, 2, 3, 4, 5, 6, 7, 8];
+		category === 0
+			? `${data && data.region} 인기 줍줍템!`
+			: `회원님 주변의 무료나눔 물품들 이에요!`;
 
 	const [swiper, setSwiper] = useState(null);
 
@@ -23,24 +25,28 @@ const Preview = ({ categoryData, userLocation, userName }) => {
 		swiper.slidePrev();
 	};
 
-	const cardList = async () => {
-		const res = await Axios.get('/api/product');
-		console.log(res);
+	const List = async () => {
+		const res = await ProductApi.mainList();
+		setData(res.data);
 	};
+
+	useEffect(() => {
+		List();
+	}, []);
 
 	return (
 		<S.Wrapper>
 			<S.UpperSwiper>
-				<S.CategoryBox>{category}</S.CategoryBox>
+				<S.CategoryBox>{categoryDeclare}</S.CategoryBox>
 				<S.CategoryText>{categoryText}</S.CategoryText>
-				<S.More onClick={cardList}> 더보기 &gt; </S.More>
+				<S.More> 더보기 &gt; </S.More>
 			</S.UpperSwiper>
 			<S.SwiperWrapper>
 				<S.Btn onClick={handlePrev}> &lt;</S.Btn>
-				<Swiper onSwiper={setSwiper} spaceBetween={0} slidesPerView={4}>
-					{itemList.map(item => (
+				<Swiper onSwiper={setSwiper} spaceBetween={0} slidesPerView={3}>
+					{products?.map(item => (
 						<SwiperSlide>
-							<ItemCard key={item} />
+							<ItemCard key={item} products={item} index={item.idx} />
 						</SwiperSlide>
 					))}
 				</Swiper>

--- a/src/Pages/Main/Desktop/index.js
+++ b/src/Pages/Main/Desktop/index.js
@@ -3,12 +3,15 @@ import Preview from './Components/preview';
 import SearchBar from 'Components/SearchBar/Desktop/SearchBar';
 import TokenService from 'Repository/TokenService';
 import { useNavigate } from 'react-router-dom';
+import RegisterBtn from 'Components/Buttons/RegisterBtn/RegisterBtn';
+import { Link } from 'react-router-dom';
 import UserApi from 'Apis/userApi';
 
 const DesktopMainPage = () => {
 	const navigate = useNavigate();
+
 	const logout = async () => {
-		const res = await UserApi.logout();
+		await UserApi.logout();
 		TokenService.removeToken();
 		navigate('/');
 	};
@@ -16,11 +19,16 @@ const DesktopMainPage = () => {
 	return (
 		<S.Wrapper>
 			<button onClick={logout}>로그아웃</button>
+			<Link to={'/register'}>
+				<S.BtnSection>
+					<RegisterBtn />
+				</S.BtnSection>
+			</Link>
 			<S.SearchSection>
 				<SearchBar />
 			</S.SearchSection>
-			<Preview></Preview>
-			<Preview></Preview>
+			<Preview category={0}></Preview>
+			<Preview category={1}></Preview>
 		</S.Wrapper>
 	);
 };
@@ -44,7 +52,13 @@ const SearchSection = styled.div`
 	align-items: center;
 	justify-content: center;
 `;
+
+const BtnSection = styled.div`
+	width: 50px;
+	height: 50px;
+`;
 const S = {
 	Wrapper,
 	SearchSection,
+	BtnSection,
 };


### PR DESCRIPTION
1. 메인페이지 : 등록한 순서대로 보여지고, 내 물품도 포함되어 등록이 됩니다. 내 물품과 남의 물품의 구분은 해당 카드를 클릭했을 때 보여지는 상세 페이지로 구분됩니다.
2. 물품 상세 페이지 : isSeller로 판매자와 구매자를 구분합니다. 사진 클릭시 새창으로 원본이미지 파일이 보여지니 클릭해보세요~
3. 관심상품 등록, 해제 : 하트버튼 컴포넌트는 물품 상세 페이지 및 카드 컴포넌트와 유기적으로 동작합니다.

물품 상세 페이지 내에 '연관 상품'과 '채팅'은 api 및 구현이 완료되는 대로 업데이트 예정입니다.