### PR TITLE
:sparkles: Feat: 마이페이지_메인 화면을 [등록 아이템]으로 지정

### DIFF
--- a/src/Pages/MyPage/index.js
+++ b/src/Pages/MyPage/index.js
@@ -6,9 +6,11 @@ import UserApi from 'Apis/userApi';
 import { Outlet } from 'react-router-dom';
 import MyUserEdit2 from './MyUserEdit2/myUserEdit2';
 import MyPageApi from 'Apis/myPageApi';
+import MyItemPage from './MyItem/Desktop/myItem';
 
 const MyPage = () => {
 	const [ToggleState, setToggleState] = useState();
+	let mount = '';
 
 	const [userInfo, setUserInfo] = useState();
 	const [userProfile, setUserProfile] = useState();
@@ -34,6 +36,8 @@ const MyPage = () => {
 
 		getUserInfo();
 		getUserProfile();
+
+		mount = 'mount';
 	}, []) 
 
 	return (
@@ -42,6 +46,7 @@ const MyPage = () => {
 			<ToggleBar setToggleState={setToggleState} />
 			{ToggleState === '유저 정보 수정' && <MyUserEdit2 userInfo={userInfo} />}
 			<Outlet />
+			{mount === '' ? <MyItemPage/> : <div></div>}
 		</S.Wrapper>
 	);
 };


### PR DESCRIPTION
마이페이지 초기 접속하면 토글 메뉴바 아래 부분에 보여지는 메뉴가 없었던 관계로, 첫번째 메뉴인 [등록 아이템]을 초기 메뉴화면으로 세팅했습니다. 마이페이지 메뉴바의 특정 메뉴를 클릭하고 새로고침하면 기존의 머무르던 메뉴 화면이 유지됩니다.
